### PR TITLE
Use pkg-config to find the X11 libraries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Install Rust
         run: rustup update ${{ matrix.rust }} && rustup default ${{ matrix.rust }}
+      - run: sudo apt update -y && sudo apt install -y libx11-xcb-dev
       - run: cargo build --all
       - run: cargo build --all --no-default-features
       - run: cargo build --all --features dlopen

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,11 +37,11 @@ jobs:
       - uses: actions/checkout@v3
       - name: Install Rust
         run: rustup update ${{ matrix.rust }} && rustup default ${{ matrix.rust }}
+      - run: sudo apt update -y && sudo apt install -y libx11-xcb-dev
       - run: cargo build --all --all-features --all-targets
       - name: Run cargo check (without dev-dependencies to catch missing feature flags)
         if: startsWith(matrix.rust, 'nightly')
         run: cargo check -Z features=dev_dep
-      - run: sudo apt update -y && sudo apt install -y libx11-xcb-dev
       - run: xvfb-run cargo test --all --jobs 1
       - run: xvfb-run cargo test --all --no-default-features --jobs 1
       - run: xvfb-run cargo test --all --features dlopen --jobs 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "tiny-xlib"
 version = "0.2.2"
 edition = "2021"
 rust-version = "1.63"
-authors = ["John Nunley <jtnunley01@gmail.com>"]
+authors = ["John Nunley <dev@notgull.net>"]
 license = "MIT OR Apache-2.0 OR Zlib"
 description = "A tiny Xlib wrapper for Rust"
 repository = "https://github.com/notgull/tiny-xlib"
@@ -25,3 +25,6 @@ tracing = "0.1.37"
 tracing-subscriber = "0.3.17"
 x11-dl = "2.21.0"
 x11rb = { version = "0.12.0", features = ["allow-unsafe-code"] }
+
+[build-dependencies]
+pkg-config = "0.3.27"

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,62 @@
+// MIT/Apache2/Zlib License
+
+//! Finds the path of Xlib and Xlib-XCB.
+//!
+//! Normally, we should be able to link directly to these packages. However, on some atypical
+//! Linux configurations (like NixOS), they might be in other directories. As far as I know
+//! `pkg-config` is the only blessed way to find and link to these libraries. So unfortunately,
+//! we have to have a heavy build script and build-time dependency.
+
+use std::io::{self, prelude::*};
+use std::path::PathBuf;
+use std::{env, fs};
+
+fn find_link_deps(deps: &[(&str, &str)]) -> Result<(), Box<dyn std::error::Error>> {
+    for (_name, pkg_config_name) in deps {
+        pkg_config::Config::new().probe(pkg_config_name)?;
+    }
+
+    Ok(())
+}
+
+fn find_dlopen_dirs(deps: &[(&str, &str)]) -> Result<(), Box<dyn std::error::Error>> {
+    let mut libdir_file = {
+        let path = PathBuf::from(env::var_os("OUT_DIR").unwrap()).join("libdir.rs");
+        let libdir_file = fs::File::create(path)?;
+        io::BufWriter::new(libdir_file)
+    };
+
+    for (name, pkg_config_name) in deps {
+        let dir = match pkg_config::get_variable(pkg_config_name, "libdir") {
+            Ok(libdir) => format!("Some(\"{}\")", libdir),
+            Err(err) => {
+                println!(
+                    "cargo:warning=failed to get libdir for library {}: {}",
+                    pkg_config_name, err
+                );
+                "None".to_string()
+            }
+        };
+
+        writeln!(
+            libdir_file,
+            "const {}_LIBDIR: Option<&str> = {};",
+            name, dir
+        )?;
+    }
+
+    libdir_file.flush()?;
+    Ok(())
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    const DEPENDENCIES: &[(&str, &str)] = &[("XLIB", "x11"), ("XLIB_XCB", "x11-xcb")];
+
+    if env::var_os("CARGO_FEATURE_DLOPEN").is_some() {
+        find_dlopen_dirs(DEPENDENCIES)?;
+    } else {
+        find_link_deps(DEPENDENCIES)?;
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
Unfortunately this is necessary to add a build script to find X11 effectively on esoteric setups, like NixOS. This should make it more reliable to find shared libraries.

Closes #3 and #6

- [x] Tested on all platforms affected by this change
- [x] Added `Signed-off-by:` to all commits to indicate that you have the rights to this change.