### PR TITLE
Switch out ctor for ctor-lite

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ dlopen = ["libloading"]
 
 [dependencies]
 as-raw-xcb-connection = "1.0.0"
-ctor = "0.2.0"
+ctor-lite = "0.1.0"
 libloading = { version = "0.8.0", optional = true }
 tracing = { version = "0.1.37", default-features = false, optional = true }
 


### PR DESCRIPTION
This removes the proc macro dependencies from this crate.

- [x] Tested on all platforms affected by this change
- [x] Added `Signed-off-by:` to all commits to indicate that you have the rights to this change.
