### PR TITLE
v0.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.2.3
+
+- Replace `ctor` with `ctor-lite` to remove proc-macro dependencies. (#12)
+
 ## v0.2.2
 
 Implement better loading on `dlopen` mode.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tiny-xlib"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2021"
 rust-version = "1.63"
 authors = ["John Nunley <dev@notgull.net>"]


### PR DESCRIPTION
- Replace `ctor` with `ctor-lite` to remove proc-macro dependencies. (#12)
