### PR TITLE
coverage(off) instead of no_coverage (rust-lang/rust PR 114656)

### DIFF
--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -115,7 +115,7 @@ impl Xlib {
     }
 
     /// Load the Xlib library at runtime.
-    #[cfg_attr(coverage, no_coverage)]
+    #[cfg_attr(coverage, coverage(off))]
     #[cfg(not(feature = "dlopen"))]
     pub(crate) fn load() -> Result<Self, std::io::Error> {
         #[link(name = "X11", kind = "dylib")]
@@ -143,7 +143,7 @@ impl Xlib {
     }
 
     /// Load the Xlib library at runtime.
-    #[cfg_attr(coverage, no_coverage)]
+    #[cfg_attr(coverage, coverage(off))]
     #[cfg(feature = "dlopen")]
     pub(crate) fn load() -> Result<Self, libloading::Error> {
         let xlib_library = unsafe { load_library(XLIB_LIBDIR, &["libX11.so.6", "libX11.so"]) }?;
@@ -178,7 +178,7 @@ impl Xlib {
 }
 
 #[cfg(feature = "dlopen")]
-#[cfg_attr(coverage, no_coverage)]
+#[cfg_attr(coverage, coverage(off))]
 unsafe fn load_library(
     prefix: Option<&str>,
     names: &[&str],


### PR DESCRIPTION
- [ ] Tested on all platforms affected by this change
- [ ] Added `Signed-off-by:` to all commits to indicate that you have the rights to this change.