### PR TITLE
Use the declarative version of `ctor` instead of `ctor-lite`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ dlopen = ["libloading"]
 
 [dependencies]
 as-raw-xcb-connection = "1.0.0"
-ctor-lite = "0.1.0"
+ctor = { version = "0.10.0", default-features = false, features = ["std"] }
 libloading = { version = "0.8.0", optional = true }
 tracing = { version = "0.1.37", default-features = false, optional = true }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -144,8 +144,9 @@ macro_rules! lock {
     }};
 }
 
-ctor_lite::ctor! {
-    unsafe static XLIB: io::Result<ffi::Xlib> = {
+ctor::declarative::ctor! {
+    #[ctor(unsafe)]
+    static XLIB: io::Result<ffi::Xlib> = {
         #[cfg_attr(coverage, no_coverage)]
         unsafe fn load_xlib_with_error_hook() -> io::Result<ffi::Xlib> {
             // Here's a puzzle: how do you *safely* add an error hook to Xlib? Like signal handling, there


### PR DESCRIPTION
@notgull is stepping down as an open-source maintainer, and has transfered `ctor-lite` to `rust-windowing` since it's used by this project. `ctor-lite` was created as an alternative to `ctor` that doesn't depend on proc-macros, but since then, `ctor` itself has gained this capability via the [`ctor::declarative`](https://docs.rs/ctor/latest/ctor/declarative/) module.

Even though I [disagree with the `ctor` maintainer on various points](https://github.com/mmastrac/rust-ctor/issues/159), I also don't have the resources to maintain a fork, so I think we should use `ctor` in this project and sunset `ctor-lite`.

This effectively reverts https://github.com/rust-windowing/tiny-xlib/pull/12.

- [ ] Tested on all platforms affected by this change
- [x] Added `Signed-off-by:` to all commits to indicate that you have the rights to this change.