### PR TITLE
Use `taiki-e/checkout-action` to avoid having to keep CI up to date

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
         os: [ubuntu-latest]
         rust: [nightly, beta, stable]
     steps:
-      - uses: actions/checkout@v3
+      - uses: taiki-e/checkout-action@v1
       - name: Install Rust
         run: rustup update ${{ matrix.rust }} && rustup default ${{ matrix.rust }}
       - run: sudo apt update -y && sudo apt install -y libx11-xcb-dev
@@ -54,7 +54,7 @@ jobs:
         # Rust version in Cargo.toml.
         rust: ['1.63']
     steps:
-      - uses: actions/checkout@v3
+      - uses: taiki-e/checkout-action@v1
       - name: Install Rust
         run: rustup update ${{ matrix.rust }} && rustup default ${{ matrix.rust }}
       - run: sudo apt update -y && sudo apt install -y libx11-xcb-dev
@@ -65,7 +65,7 @@ jobs:
   clippy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: taiki-e/checkout-action@v1
       - name: Install Rust
         run: rustup update stable
       - run: cargo clippy --all --all-features --all-targets
@@ -73,7 +73,7 @@ jobs:
   fmt:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: taiki-e/checkout-action@v1
       - name: Install Rust
         run: rustup update stable
       - run: cargo fmt --all --check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     if: github.repository_owner == 'notgull'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: taiki-e/checkout-action@v1
       - uses: taiki-e/create-gh-release-action@v1
         with:
           changelog: CHANGELOG.md


### PR DESCRIPTION
`actions/checkout` updates fairly often.