### PR TITLE
Fix CI and bump MSRV to 1.70

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,12 +53,23 @@ jobs:
         rust: ['1.63']
     steps:
       - uses: taiki-e/checkout-action@v1
+      - name: Use minimal dependency versions
+        # By downgrading all our dependency versions, we ensure that our minimum
+        # version bounds are actually adequate (i.e. users can build `tiny-xlib`
+        # with minimal versions themselves) and opt-out of any unexpected MSRV
+        # bumps in semver-compatible releases of downstream crates.
+        #
+        # RUSTC_BOOTSTRAP=1 is kind of a hack, but it's cumbersome and slow to
+        # install the nightly toolchain.
+        run: RUSTC_BOOTSTRAP=1 cargo -Zminimal-versions generate-lockfile
       - name: Install Rust
         run: rustup update ${{ matrix.rust }} && rustup default ${{ matrix.rust }}
       - run: sudo apt update -y && sudo apt install -y libx11-xcb-dev
       - run: cargo build --all
       - run: cargo build --all --no-default-features
       - run: cargo build --all --features dlopen
+    env:
+      RUSTFLAGS: ''
 
   clippy:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
       matrix:
         # When updating this, the reminder to update the minimum supported
         # Rust version in Cargo.toml.
-        rust: ['1.63']
+        rust: ['1.70']
     steps:
       - uses: taiki-e/checkout-action@v1
       - name: Use minimal dependency versions

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,6 @@ on:
   push:
     branches:
       - main
-  schedule:
-    - cron: '0 2 * * 0'
 
 env:
   CARGO_INCREMENTAL: 0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ dlopen = ["libloading"]
 [dependencies]
 as-raw-xcb-connection = "1.0.0"
 ctor = { version = "0.10.0", default-features = false, features = ["std"] }
-libloading = { version = "0.9.0", optional = true }
+libloading = { version = "0.8.0", optional = true }
 tracing = { version = "0.1.37", default-features = false, optional = true }
 
 [build-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "tiny-xlib"
 version = "0.2.4"
 edition = "2021"
-rust-version = "1.63"
+rust-version = "1.70"
 authors = ["John Nunley <dev@notgull.net>"]
 license = "MIT OR Apache-2.0 OR Zlib"
 description = "A tiny Xlib wrapper for Rust"


### PR DESCRIPTION
This also bumps MSRV to 1.70 - we could probably re-implement `OnceLock` ourselves and get it down further, but I'd rather not bother.

This PR also reverts https://github.com/rust-windowing/tiny-xlib/pull/17.

- [ ] Tested on all platforms affected by this change
- [x] Added `Signed-off-by:` to all commits to indicate that you have the rights to this change.