### PR TITLE
v0.2.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v0.2.5
+
+- Replace `ctor-lite` with `ctor` (the latter is maintained). (#20)
+- Move to the [`@rust-windowing`](https://github.com/rust-windowing) GitHub organization. (#21)
+- Fix building with `--cfg coverage` enabled. (#23)
+- Bump MSRV to 1.70. (#25)
+
 ## v0.2.4
 
 - Add `default_screen()` function for getting the index of the default screen. (#14)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tiny-xlib"
-version = "0.2.4"
+version = "0.2.5"
 edition = "2021"
 rust-version = "1.70"
 authors = ["John Nunley <dev@notgull.net>"]


### PR DESCRIPTION
- [ ] Tested on all platforms affected by this change
- [x] Added `Signed-off-by:` to all commits to indicate that you have the rights to this change.